### PR TITLE
workflow追加

### DIFF
--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -28,7 +28,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: |
-            ${{ github.workspace }}/**/build/reports/jacoco/codeCoverageReport/testCodeCoverageReport.xml,
+            ${{ github.workspace }}/**/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -21,14 +21,15 @@ jobs:
       - name: Run Coverage
         run: |
           chmod +x gradlew
-          ./gradlew testCodeCoverageReport
+          ./gradlew jacocoTestReport
 
       - name: Add coverage to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: |
-            ${{ github.workspace }}/**/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml,
+            ${{ github.workspace }}/**/model/build/reports/jacoco/test/jacocoTestReport.xml,
+            ${{ github.workspace }}/**/view/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -1,0 +1,32 @@
+name: Measure coverage
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+      - name: Run Coverage
+        run: |
+          chmod +x gradlew
+          ./gradlew testCoverage
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: |
+            ${{ github.workspace }}/**/build/reports/jacoco/prodNormalDebugCoverage/prodNormalDebugCoverage.xml,
+            ${{ github.workspace }}/**/build/reports/jacoco/**/debugCoverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 40
+          min-coverage-changed-files: 60

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run Coverage
         run: |
           chmod +x gradlew
-          ./gradlew testCoverage
+          ./gradlew codeCoverageReport
 
       - name: Add coverage to PR
         id: jacoco

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -33,4 +33,4 @@ jobs:
             ${{ github.workspace }}/**/view/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
-          min-coverage-changed-files: 60
+          min-coverage-changed-files: 0

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -32,5 +32,5 @@ jobs:
             ${{ github.workspace }}/**/model/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/**/view/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 90
-          min-coverage-changed-files: 0
+          min-coverage-overall: 40
+          min-coverage-changed-files: 60

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Coverage
         run: |
           chmod +x gradlew
-          ./gradlew codeCoverageReport
+          ./gradlew testCodeCoverageReport
 
       - name: Add coverage to PR
         id: jacoco

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -28,7 +28,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: |
-            ${{ github.workspace }}/**/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml,
+            ${{ github.workspace }}/**/build/reports/jacoco/codeCoverageReport/testCodeCoverageReport.xml,
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -28,6 +28,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: |
+            ${{ github.workspace }}/**/controller/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/**/model/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/**/view/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -9,12 +9,15 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '17'
+
+      - name: checkout
+        uses: actions/checkout@v4
+
       - name: Run Coverage
         run: |
           chmod +x gradlew

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -32,5 +32,5 @@ jobs:
             ${{ github.workspace }}/**/model/build/reports/jacoco/test/jacocoTestReport.xml,
             ${{ github.workspace }}/**/view/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 40
+          min-coverage-overall: 90
           min-coverage-changed-files: 0

--- a/.github/workflows/jacoco-report.yml
+++ b/.github/workflows/jacoco-report.yml
@@ -28,8 +28,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: |
-            ${{ github.workspace }}/**/build/reports/jacoco/prodNormalDebugCoverage/prodNormalDebugCoverage.xml,
-            ${{ github.workspace }}/**/build/reports/jacoco/**/debugCoverage.xml
+            ${{ github.workspace }}/**/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml,
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,10 +57,6 @@ tasks.withType<Test> {
 }
 
 tasks.register<JacocoReport>("codeCoverageReport") {
-    reports {
-        xml.required.set(true)
-    }
-
     subprojects {
         val subproject = this
         subproject.plugins.withType<JacocoPlugin>().configureEach {
@@ -71,6 +67,16 @@ tasks.register<JacocoReport>("codeCoverageReport") {
                     sourceSets(subproject.sourceSets.main.get())
                     executionData(testTask)
                 }
+
+            subproject.tasks
+                .matching { it.extensions.findByType<JacocoTaskExtension>() != null }
+                .forEach {
+                    rootProject.tasks["codeCoverageReport"].dependsOn(it)
+                }
         }
+    }
+
+    reports {
+        xml.required.set(true)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,10 +57,13 @@ tasks.withType<Test> {
 }
 
 tasks.register<JacocoReport>("codeCoverageReport") {
+    reports {
+        xml.required.set(true)
+    }
+
     subprojects {
         val subproject = this
         subproject.plugins.withType<JacocoPlugin>().configureEach {
-
             subproject.tasks
                 .matching { it.extensions.findByType<JacocoTaskExtension>() != null }
                 .configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,12 +9,6 @@ plugins {
     id("jacoco-report-aggregation")
 }
 
-dependencies {
-    jacocoAggregation(project(":controller"))
-    jacocoAggregation(project(":model"))
-    jacocoAggregation(project(":view"))
-}
-
 allprojects {
     group = "com.example"
     version = "0.0.1-SNAPSHOT"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,14 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.jacocoTestReport {
+    reports {
+        xml.required.set(true)
+        csv.required.set(false)
+        html.outputLocation.set(file("${buildDir}/reports/jacoco"))
+    }
+}
+
 tasks.register<JacocoReport>("codeCoverageReport") {
     subprojects {
         val subproject = this
@@ -69,9 +77,5 @@ tasks.register<JacocoReport>("codeCoverageReport") {
                     executionData(testTask)
                 }
         }
-    }
-
-    reports {
-        xml.required.set(true)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 dependencies {
     jacocoAggregation(project(":controller"))
     jacocoAggregation(project(":model"))
+    jacocoAggregation(project(":view"))
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
     id("org.springframework.boot") version "3.3.4"
     id("io.spring.dependency-management") version "1.1.6"
     id("jacoco")
+    id("jacoco-report-aggregation")
+}
+
+dependencies {
+    jacocoAggregation(project(":controller"))
+    jacocoAggregation(project(":model"))
 }
 
 allprojects {
@@ -66,12 +72,6 @@ tasks.register<JacocoReport>("codeCoverageReport") {
                     val testTask = this
                     sourceSets(subproject.sourceSets.main.get())
                     executionData(testTask)
-                }
-
-            subproject.tasks
-                .matching { it.extensions.findByType<JacocoTaskExtension>() != null }
-                .forEach {
-                    rootProject.tasks["codeCoverageReport"].dependsOn(it)
                 }
         }
     }

--- a/controller/build.gradle.kts
+++ b/controller/build.gradle.kts
@@ -11,3 +11,7 @@ dependencies {
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     mainClass.set("com.example.jacocosandbox.JacocoSandboxApplicationKt")
 }
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+}

--- a/controller/build.gradle.kts
+++ b/controller/build.gradle.kts
@@ -11,7 +11,3 @@ dependencies {
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     mainClass.set("com.example.jacocosandbox.JacocoSandboxApplicationKt")
 }
-
-tasks.jacocoTestReport {
-    dependsOn(tasks.test)
-}

--- a/controller/build.gradle.kts
+++ b/controller/build.gradle.kts
@@ -11,3 +11,12 @@ dependencies {
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
     mainClass.set("com.example.jacocosandbox.JacocoSandboxApplicationKt")
 }
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+
+    reports {
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+}

--- a/controller/src/test/kotlin/com/example/jacocosandbox/controller/GreetingControllerTest.kt
+++ b/controller/src/test/kotlin/com/example/jacocosandbox/controller/GreetingControllerTest.kt
@@ -1,0 +1,43 @@
+package com.example.jacocosandbox.controller
+
+import com.example.jacocosandbox.model.GetGreeting
+import com.example.jacocosandbox.view.Greeting
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@WebMvcTest(GreetingController::class)
+class GreetingControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var getGreeting: GetGreeting
+
+    @Test
+    fun `nameに指定がない場合、Hello, World!が返ること`() {
+        `when`(getGreeting("World")).thenReturn(
+            Greeting(
+                id = 1,
+                content = "Hello, World!",
+            )
+        )
+
+        // Act & Assert
+        mockMvc.get("/greeting")
+            .andExpect {
+                status { isOk() }
+                content {
+                    Greeting(
+                        id = 1,
+                        content = "Hello, World!",
+                    )
+                }
+            }
+    }
+}

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -5,7 +5,3 @@ apply {
 dependencies {
     implementation(project(":view"))
 }
-
-tasks.jacocoTestReport {
-    dependsOn(tasks.test)
-}

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -5,3 +5,7 @@ apply {
 dependencies {
     implementation(project(":view"))
 }
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+}

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -5,3 +5,12 @@ apply {
 dependencies {
     implementation(project(":view"))
 }
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+
+    reports {
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+}

--- a/model/src/main/kotlin/com/example/jacocosandbox/model/GetGreeting.kt
+++ b/model/src/main/kotlin/com/example/jacocosandbox/model/GetGreeting.kt
@@ -11,6 +11,10 @@ class GetGreeting {
 
     operator fun invoke(name: String): Greeting {
         val id = counter.incrementAndGet()
+        if (id <= 0) {
+            throw ArithmeticException()
+        }
+
         val content = String.format(template, name)
 
         return Greeting(id, content)

--- a/view/build.gradle.kts
+++ b/view/build.gradle.kts
@@ -1,3 +1,12 @@
 apply {
     plugin("org.springframework.boot")
 }
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+
+    reports {
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+}

--- a/view/src/main/kotlin/com/example/jacocosandbox/view/Greeting.kt
+++ b/view/src/main/kotlin/com/example/jacocosandbox/view/Greeting.kt
@@ -3,4 +3,9 @@ package com.example.jacocosandbox.view
 data class Greeting(
     val id: Long,
     val content: String,
-)
+) {
+
+    companion object {
+        val EMPTY = Greeting(-1, "")
+    }
+}

--- a/view/src/test/kotlin/com/example/jacocosandbox/view/GreetingTest.kt
+++ b/view/src/test/kotlin/com/example/jacocosandbox/view/GreetingTest.kt
@@ -1,0 +1,17 @@
+package com.example.jacocosandbox.view
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GreetingTest{
+    @Test
+    fun `値の確認`() {
+        val expected =
+            Greeting(
+                id = 1,
+                content = "Hello, Test!",
+            )
+
+        assertEquals(expected, Greeting(1, "Hello, Test!"))
+    }
+}


### PR DESCRIPTION
## 内容

サブプロジェクト別にコードカバレッジレポートをPR上に流す

## 理解内容

* モジュール別のCoverage：index.html > totalのcovered / overall
* ファイル別のCoverage：各ファイル.html > totalのcovered / overall

## 課題

* 実装の変更点に対してのみレポートが出力されるため、UT実装のみの場合出力されない
